### PR TITLE
Follow symlinks

### DIFF
--- a/context.js
+++ b/context.js
@@ -6,7 +6,13 @@ function context(basedir, directory, useSubdirectories = false, regExp = /^\.\//
     let result = [];
     fs.readdirSync(path.join(basedir, dir)).forEach(function(file) {
       const relativePath = dir + '/' + file;
-      const stats = fs.lstatSync(path.join(basedir, relativePath));
+      let filepath = path.join(basedir, relativePath);
+      let stats = fs.lstatSync(filepath);
+      while (stats.isSymbolicLink()) {
+        filepath = fs.realpathSync(filepath);
+        stats = fs.lstatSync(filepath);
+      }
+
       if (stats.isDirectory()) {
         if (useSubdirectories) {
           result = result.concat(enumerateFiles(basedir, relativePath));


### PR DESCRIPTION
We are currently following symlinks in our jest snapshot generation.

Would you be interested in integrating this as default behavior?

This matches webpack `require.context` behavior in our lerna monorepo.